### PR TITLE
fixed metadata color

### DIFF
--- a/src/components/user/profile/header.tsx
+++ b/src/components/user/profile/header.tsx
@@ -35,36 +35,36 @@ const Header = ({
       <div className="flex max-h-full w-full max-w-full flex-col gap-1">
         <p className="text-3xl font-bold">{name}</p>
 
-        <div className="flex items-center gap-2">
-          <Mail className="h-5 w-5 text-starlight-gray" />
+        <div className="flex items-center">
           <Link
             href={`mailto:${email}`}
             className="text-starlight-gray"
             target="_blank"
           >
-            {email}
+            <Mail className="inline-block h-5 w-5 text-starlight-gray" />
+            <span className="ml-2">{email}</span>
           </Link>
         </div>
 
         <div className="flex items-center gap-2">
-          <FaGithub className="h-5 w-5 text-starlight-gray" />
           <Link
             href={`https://github.com/${github}`}
             className="text-starlight-gray"
             target="_blank"
           >
-            {github}
+            <FaGithub className="inline h-5 w-5 text-starlight-gray" />
+            <span className="ml-2">{github}</span>
           </Link>
         </div>
 
         <div className="flex items-center gap-2">
-          <FaDiscord className="h-5 w-5 text-starlight-gray" />
           <Link
             href={`https://discord.com/users/${discord}`}
             className="text-starlight-gray"
             target="_blank"
           >
-            {discord}
+            <FaDiscord className="inline-block h-5 w-5 text-starlight-gray" />
+            <span className="ml-2">{discord}</span>
           </Link>
         </div>
         <div className="flex max-w-full items-center">

--- a/src/components/user/profile/header.tsx
+++ b/src/components/user/profile/header.tsx
@@ -36,17 +36,17 @@ const Header = ({
         <p className="text-3xl font-bold">{name}</p>
 
         <div className="flex items-center gap-2">
-          <Mail className="h-5 w-5" />
-          <Link href={`mailto:${email}`} className="text-base" target="_blank">
+          <Mail className="h-5 w-5 text-starlight-gray" />
+          <Link href={`mailto:${email}`} className=" text-starlight-gray" target="_blank">
             {email}
           </Link>
         </div>
 
         <div className="flex items-center gap-2">
-          <FaGithub className="h-5 w-5" />
+          <FaGithub className="h-5 w-5 text-starlight-gray" />
           <Link
             href={`https://github.com/${github}`}
-            className="text-base"
+            className="text-starlight-gray"
             target="_blank"
           >
             {github}
@@ -54,10 +54,10 @@ const Header = ({
         </div>
 
         <div className="flex items-center gap-2">
-          <FaDiscord className="h-5 w-5" />
+          <FaDiscord className="h-5 w-5 text-starlight-gray" />
           <Link
             href={`https://discord.com/users/${discord}`}
-            className="text-base"
+            className="text-starlight-gray"
             target="_blank"
           >
             {discord}

--- a/src/components/user/profile/header.tsx
+++ b/src/components/user/profile/header.tsx
@@ -37,7 +37,11 @@ const Header = ({
 
         <div className="flex items-center gap-2">
           <Mail className="h-5 w-5 text-starlight-gray" />
-          <Link href={`mailto:${email}`} className=" text-starlight-gray" target="_blank">
+          <Link
+            href={`mailto:${email}`}
+            className="text-starlight-gray"
+            target="_blank"
+          >
             {email}
           </Link>
         </div>


### PR DESCRIPTION
<img width="757" alt="Screenshot 2024-11-04 at 12 06 21 AM" src="https://github.com/user-attachments/assets/afec6ec7-2d7c-4e10-9e56-f5a825d864fc">

-changed text color to gray for email, github, and discord.