### PR TITLE
made text black on hover

### DIFF
--- a/src/components/global/navigation/side.tsx
+++ b/src/components/global/navigation/side.tsx
@@ -21,7 +21,7 @@ const SideNav = ({ links }: props) => {
           <Link
             key={index}
             href={link}
-            className="!w-full hover:bg-starlight-yellow"
+            className="!w-full hover:bg-starlight-yellow hover:text-black"
           >
             {name}
           </Link>


### PR DESCRIPTION

![navHoverFix](https://github.com/user-attachments/assets/a79b1702-fcae-4783-859a-246bd2bebbf3)

- changed text color to black on hover over side nav
- it seems like highlight across bar was already fixed before me
- closes #43 